### PR TITLE
Add matomo analytics to general plan mapper

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,11 @@
     sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/static/cssjs/css/font-awesome.css">
     <link rel="stylesheet" href="/static/cssjs/css/general-template.css">
-  
+
+    <!-- Matomo --><script  type="text/javascript">var _paq = window._paq = window._paq || [];
+_paq.push(['disableCookies']);
+_paq.push(['enableJSErrorTracking']);_paq.push(['trackPageView']);_paq.push(['enableLinkTracking']);_paq.push(['alwaysUseSendBeacon']);_paq.push(['setTrackerUrl', "\/\/critical-data-analysis.org\/wp-content\/plugins\/matomo\/app\/matomo.php"]);_paq.push(['setSiteId', '1']);var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.type='text/javascript'; g.async=true; g.src="\/\/critical-data-analysis.org\/wp-content\/uploads\/matomo\/matomo.js"; s.parentNode.insertBefore(g,s);</script><!-- End Matomo Code -->  
 
     </head>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,10 +21,24 @@
     <link rel="stylesheet" type="text/css" href="/static/cssjs/css/font-awesome.css">
     <link rel="stylesheet" href="/static/cssjs/css/general-template.css">
 
-    <!-- Matomo --><script  type="text/javascript">var _paq = window._paq = window._paq || [];
-_paq.push(['disableCookies']);
-_paq.push(['enableJSErrorTracking']);_paq.push(['trackPageView']);_paq.push(['enableLinkTracking']);_paq.push(['alwaysUseSendBeacon']);_paq.push(['setTrackerUrl', "\/\/critical-data-analysis.org\/wp-content\/plugins\/matomo\/app\/matomo.php"]);_paq.push(['setSiteId', '1']);var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-g.type='text/javascript'; g.async=true; g.src="\/\/critical-data-analysis.org\/wp-content\/uploads\/matomo\/matomo.js"; s.parentNode.insertBefore(g,s);</script><!-- End Matomo Code -->  
+    <!-- Matomo -->
+    <script  type="text/javascript">
+        var _paq = window._paq = window._paq || [];
+        _paq.push(['disableCookies']);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        _paq.push(['alwaysUseSendBeacon']);
+        _paq.push(['setTrackerUrl', "https://critical-data-analysis.org/wp-content/plugins/matomo/app/matomo.php"]);
+        _paq.push(['setSiteId', '1']);
+        var d=document,
+            g=d.createElement('script'),
+            s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript';
+            g.async=true;
+            g.src="https://critical-data-analysis.org/wp-content/uploads/matomo/matomo.js";
+            s.parentNode.insertBefore(g,s);
+    </script>
+    <!-- End Matomo Code -->
 
     </head>
 


### PR DESCRIPTION
added code to the `index.html` template to send usage stats to the [https://critical-data-analysis.org/](https://critical-data-analysis.org/) logs